### PR TITLE
chore: move more html into shortcodes

### DIFF
--- a/content/de/about/index.md
+++ b/content/de/about/index.md
@@ -7,69 +7,27 @@ title: Über uns
 Obwohl wir noch ein junges Unternehmen sind, haben wir bereits einige namhafte Kunden gewinnen können.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.ace.ch/">
-                    <img src="customers/ace.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bedag.ch/">
-                    <img src="customers/bedag.png">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bfh.ch/">
-                    <img src="customers/bfh.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bison-group.com/">
-                    <img src="customers/bison.svg">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://admin.ch/">
-                    <img src="customers/bund.svg">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.gelan.ch/">
-                    <img src="customers/gelan.png">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.mobiliar.ch/">
-                    <img src="customers/mobiliar.svg">
-                </a>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="customers/ace.png"
+      href="https://www.ace.ch/" >}}
+  {{< grid-item
+      image="customers/bedag.png"
+      href="https://www.bedag.ch/" >}}
+  {{< grid-item
+      image="customers/bfh.svg"
+      href="https://www.bfh.ch/" >}}
+  {{< grid-item
+      image="customers/bison.svg"
+      href="https://www.bison-group.com/" >}}
+  {{< grid-item
+      image="customers/bund.svg"
+      href="https://admin.ch/" >}}
+  {{< grid-item
+      image="customers/gelan.png"
+      href="https://www.gelan.ch/" >}}
+  {{< grid-item
+      image="customers/mobiliar.svg"
+      href="https://www.mobiliar.ch/" >}}
 </div>
 
 ## Partner
@@ -78,58 +36,22 @@ Mit dem heutigen Fachkräftemangel sind ein breites Netzwerk und strategische Pa
 unseres Erfolgs.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://avega.ch/">
-                    <img src="partners/avega.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://bespinian.io/">
-                    <img src="partners/bespinian.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.kiwi.ch/">
-                    <img src="partners/kiwi.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://nuvibit.com/">
-                    <img src="partners/nuvibit.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://origoss.com/">
-                    <img src="partners/origoss.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.zooey.ch/">
-                    <img src="partners/zooey.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="partners/avega.svg"
+      href="https://avega.ch/" >}}
+  {{< grid-item
+      image="partners/bespinian.svg"
+      href="https://bespinian.io/" >}}
+  {{< grid-item
+      image="partners/kiwi.png"
+      href="https://kiwi.ch/" >}}
+  {{< grid-item
+      image="partners/nuvibit.png"
+      href="https://nuvibit.com/" >}}
+  {{< grid-item
+      image="partners/origoss.svg"
+      href="https://origoss.com/" >}}
+  {{< grid-item
+      image="partners/zooey.svg"
+      href="https://www.zooey.ch/" >}}
 </div>

--- a/content/de/services/index.md
+++ b/content/de/services/index.md
@@ -9,50 +9,17 @@ entwickelt, sodass sie der kontinuierlichen Veränderung Rechnung tragen und sic
 unserer Erfahrung unterstützen wir auf dem Weg zur modernen IT Architektur in der Cloud.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/cloud-bolt.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Wir unterstützen auf dem Weg zur individuellen Cloud Journey.</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/cubes.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Wir beurteilen und challengen bestehende Lösungen und helfen beim Aufbau und
-                    Design von neuen Umgebungen.</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/diagram-project.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Unser Fokus liegt auf pragmatischen und evolutionären
-                    Architekturansätzen.</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/cloud-bolt.svg"
+      text="Wir unterstützen auf dem Weg zur individuellen Cloud Journey." >}}
+
+  {{< grid-item
+      image="services/cubes.svg"
+      text="Wir beurteilen und challengen bestehende Lösungen und helfen beim Aufbau und Design von neuen Umgebungen." >}}
+
+  {{< grid-item
+      image="services/diagram-project.svg"
+      text="Unser Fokus liegt auf pragmatischen und evolutionären Architekturansätzen." >}}
 </div>
 
 ## Engineering
@@ -61,160 +28,49 @@ Als leidenschaftliche Software und Infrastructure Engineers helfen wir beim Desi
 Implementierung moderner Technologien und Methoden.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/harbor.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Artefakte mit Harbor</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/argo.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">GitOps mit Argo CD und Flux CD</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/slsa.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Supply Chain Security mit SLSA und Sigstore</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/backstage.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Internal Developer Portals</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/kubernetes.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Container und Kubernetes</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/gitlab.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Continuous Integration, Delivery und Deployment (CI/CD)</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/terraform.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Infrastructure as Code (IaC) und Configuration as Code</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/gopher.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Durchgängige Automatisierung</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/prometheus.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Observability</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/func.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Serverless</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/keycloak.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Authentifizierung</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/harbor.svg"
+      text="Artefakte mit Harbor" >}}
+
+  {{< grid-item
+      image="services/argo.svg"
+      text="GitOps mit Argo CD und Flux CD" >}}
+
+  {{< grid-item
+      image="services/slsa.svg"
+      text="Supply Chain Security mit SLSA und Sigstore" >}}
+
+  {{< grid-item
+      image="services/backstage.svg"
+      text="Internal Developer Portals" >}}
+
+  {{< grid-item
+      image="services/kubernetes.svg"
+      text="Container und Kubernetes" >}}
+
+  {{< grid-item
+      image="services/gitlab.svg"
+      text="Continuous Integration, Delivery und Deployment (CI/CD)" >}}
+
+  {{< grid-item
+      image="services/terraform.svg"
+      text="Infrastructure as Code (IaC) und Configuration as Code" >}}
+
+  {{< grid-item
+      image="services/gopher.svg"
+      text="Durchgängige Automatisierung" >}}
+
+  {{< grid-item
+      image="services/prometheus.svg"
+      text="Observability" >}}
+
+  {{< grid-item
+      image="services/func.svg"
+      text="Serverless" >}}
+
+  {{< grid-item
+      image="services/keycloak.svg"
+      text="Authentifizierung" >}}
 </div>
 
 
@@ -224,34 +80,12 @@ Gerne geben wir unsere Erfahrung aus Praxis und Theorie weiter. In Form von indi
 Architektur-Workshops oder umfangreichen, technischen Trainings.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/chalkboard-user.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">IT Architektur Workshops</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/cncf.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Cloud Native Trainings für technisch versierte Engineers</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/chalkboard-user.svg"
+      text="IT Architektur Workshops" >}}
+  {{< grid-item
+      image="services/cncf.svg"
+      text="Cloud Native Trainings für technisch versierte Engineers" >}}
 </div>
 
 ## Community
@@ -261,64 +95,24 @@ Menschen aus unterschiedlichsten Bereichen. Deswegen bringen wir Leute zusammen 
 Events. Unser Netzwerk und die gute Zusammenarbeit zu unterschiedlichsten Schweizer IT Firmen zeichnet uns aus.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://cloudnativeday.ch/"><img src="community/cloudnativeday.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://cloudnativeday.ch/">
-            Swiss Cloud Native Day
-          </a></h2>
-          <p class="article__excerpt">Wir sind Co-Organisatoren des Swiss Cloud Native Days.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://www.meetup.com/cloudnativebern/"><img src="community/meetup.svg"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://www.meetup.com/cloudnativebern/">
-            Cloud Native Bern Meetup
-          </a></h2>
-          <p class="article__excerpt">Wir sind Co-Organisatoren des Cloud Native Bern Meetups.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://bernerit.rocks/"><img src="community/berneritrocks.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://bernerit.rocks/">
-            bernerit.rocks
-          </a></h2>
-          <p class="article__excerpt">Wir sind Mitgründer des Vereins bernerit.rocks.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://digitalimpact.ch/"><img src="community/digitalimpact.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://digitalimpact.ch/">
-            Digital Impact Network
-          </a></h2>
-          <p class="article__excerpt">Wir engagieren uns im Digital Impact Network in der Fachgruppe Cloud Native & DevOps.</p>
-        </div>
-      </div>
-    </div>
+  {{< grid-item
+      image="community/cloudnativeday.png"
+      title="Swiss Cloud Native Day"
+      text="Wir sind Co-Organisatoren des Swiss Cloud Native Days."
+      href="https://cloudnativeday.ch/" >}}
+  {{< grid-item
+      image="community/meetup.svg"
+      title="Cloud Native Bern Meetup"
+      text="Wir sind Co-Organisatoren des Cloud Native Bern Meetups."
+      href="https://www.meetup.com/cloudnativebern/" >}}
+  {{< grid-item
+      image="community/berneritrocks.png"
+      title="bernerit.rocks"
+      text="Wir sind Mitgründer des Vereins bernerit.rocks."
+      href="https://bernerit.rocks/" >}}
+  {{< grid-item
+      image="community/digitalimpact.png"
+      title="Digital Impact Network"
+      text="Wir engagieren uns im Digital Impact Network in der Fachgruppe Cloud Native & DevOps."
+      href="https://digitalimpact.ch/" >}}
 </div>

--- a/content/en/about/index.md
+++ b/content/en/about/index.md
@@ -7,69 +7,27 @@ title: About
 Although we are still a young company, we have already been able to win some well-known customers.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.ace.ch/">
-                    <img src="customers/ace.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bedag.ch/">
-                    <img src="customers/bedag.png">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bfh.ch/">
-                    <img src="customers/bfh.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.bison-group.com/">
-                    <img src="customers/bison.svg">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://admin.ch/">
-                    <img src="customers/bund.svg">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.gelan.ch/">
-                    <img src="customers/gelan.png">
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.mobiliar.ch/">
-                    <img src="customers/mobiliar.svg">
-                </a>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="customers/ace.png"
+      href="https://www.ace.ch/" >}}
+  {{< grid-item
+      image="customers/bedag.png"
+      href="https://www.bedag.ch/" >}}
+  {{< grid-item
+      image="customers/bfh.svg"
+      href="https://www.bfh.ch/" >}}
+  {{< grid-item
+      image="customers/bison.svg"
+      href="https://www.bison-group.com/" >}}
+  {{< grid-item
+      image="customers/bund.svg"
+      href="https://admin.ch/" >}}
+  {{< grid-item
+      image="customers/gelan.png"
+      href="https://www.gelan.ch/" >}}
+  {{< grid-item
+      image="customers/mobiliar.svg"
+      href="https://www.mobiliar.ch/" >}}
 </div>
 
 ## Partners
@@ -77,58 +35,22 @@ Although we are still a young company, we have already been able to win some wel
 With today's shortage of skilled staff, a broad network and strategic partnerships are an important part of our success.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://avega.ch/">
-                    <img src="partners/avega.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://bespinian.io/">
-                    <img src="partners/bespinian.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.kiwi.ch/">
-                    <img src="partners/kiwi.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://nuvibit.com/">
-                    <img src="partners/nuvibit.png"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://origoss.com/">
-                    <img src="partners/origoss.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-        <div class="sqr_border">
-            <div class="sqr">
-                <a href="https://www.zooey.ch/">
-                    <img src="partners/zooey.svg"/>
-                </a>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="partners/avega.svg"
+      href="https://avega.ch/" >}}
+  {{< grid-item
+      image="partners/bespinian.svg"
+      href="https://bespinian.io/" >}}
+  {{< grid-item
+      image="partners/kiwi.png"
+      href="https://kiwi.ch/" >}}
+  {{< grid-item
+      image="partners/nuvibit.png"
+      href="https://nuvibit.com/" >}}
+  {{< grid-item
+      image="partners/origoss.svg"
+      href="https://origoss.com/" >}}
+  {{< grid-item
+      image="partners/zooey.svg"
+      href="https://www.zooey.ch/" >}}
 </div>

--- a/content/en/services/index.md
+++ b/content/en/services/index.md
@@ -7,49 +7,17 @@ title: Services
 The IT landscape is constantly evolving, and as a result, it is important to approach architecture development in a pragmatic and evolutionary way, allowing for continuous adaptation to new circumstances. Drawing on our expertise, we provide support in the journey towards modern cloud-based IT architecture.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/cloud-bolt.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">We support you on the way to your individual cloud journey.</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/cubes.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">We assess and challenge existing solutions and assist in the construction
-                and the design of new environments.</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/diagram-project.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Our focus lies on pragmatic and evolutionary architectural approaches.</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/cloud-bolt.svg"
+      text="We support you on the way to your individual cloud journey." >}}
+
+  {{< grid-item
+      image="services/cubes.svg"
+      text="We assess and challenge existing solutions and assist in the construction and the design of new environments." >}}
+
+  {{< grid-item
+      image="services/diagram-project.svg"
+      text="Our focus lies on pragmatic and evolutionary architectural approaches." >}}
 </div>
 
 ## Engineering
@@ -58,160 +26,49 @@ As passionate software and infrastructure engineers, we assist with the design, 
 technologies and methods.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/harbor.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Artifacts with Harbor</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/argo.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">GitOps with Argo CD and Flux CD</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/slsa.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Supply Chain Security with SLSA and Sigstore</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/backstage.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Internal Developer Portals</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/kubernetes.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Containers and Kubernetes</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/gitlab.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Continuous Integration, Delivery, and Deployment (CI/CD)</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/terraform.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Infrastructure as Code (IaC) and Configuration as Code</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/gopher.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">End-to-end automation</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/prometheus.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Observability</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/func.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Serverless</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/keycloak.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Authentication</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/harbor.svg"
+      text="Artifacts with Harbor" >}}
+
+  {{< grid-item
+      image="services/argo.svg"
+      text="GitOps with Argo CD and Flux CD" >}}
+
+  {{< grid-item
+      image="services/slsa.svg"
+      text="Supply Chain Security with SLSA and Sigstore" >}}
+
+  {{< grid-item
+      image="services/backstage.svg"
+      text="Internal Developer Portals" >}}
+
+  {{< grid-item
+      image="services/kubernetes.svg"
+      text="Containers and Kubernetes" >}}
+
+  {{< grid-item
+      image="services/gitlab.svg"
+      text="Continuous Integration, Delivery, and Deployment (CI/CD)" >}}
+
+  {{< grid-item
+      image="services/terraform.svg"
+      text="Infrastructure as Code (IaC) and Configuration as Code" >}}
+
+  {{< grid-item
+      image="services/gopher.svg"
+      text="End-to-end automation" >}}
+
+  {{< grid-item
+      image="services/prometheus.svg"
+      text="Observability" >}}
+
+  {{< grid-item
+      image="services/func.svg"
+      text="Serverless" >}}
+
+  {{< grid-item
+      image="services/keycloak.svg"
+      text="Authentication" >}}
 </div>
 
 ## Training
@@ -219,34 +76,12 @@ technologies and methods.
 We are happy to pass on our experience from practice and theory. In the form of customizable architecture workshops or comprehensive technical training.
 
 <div class="row">
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img class="border" src="services/chalkboard-user.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">IT architecture workshops</p>
-            </div>
-        </div>
-    </div>
-    <div class="article col col-3 col-d-3 col-t-4">
-        <div class="article__inner">
-            <div class="article__head">
-                <div class="sqr_border">
-                    <div class="sqr">
-                        <img src="services/cncf.svg">
-                    </div>
-                </div>
-            </div>
-            <div class="article__content">
-                <p class="article__excerpt">Cloud Native trainings for tech-savvy engineers</p>
-            </div>
-        </div>
-    </div>
+  {{< grid-item
+      image="services/chalkboard-user.svg"
+      text="IT architecture workshops" >}}
+  {{< grid-item
+      image="services/cncf.svg"
+      text="Cloud Native trainings for tech-savvy engineers" >}}
 </div>
 
 ## Community
@@ -256,64 +91,24 @@ we bring people together and organize community events. Our network and good col
 companies distinguishes us.
 
 <div class="row">
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://cloudnativeday.ch/"><img src="community/cloudnativeday.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://cloudnativeday.ch/">
-            Swiss Cloud Native Day
-          </a></h2>
-          <p class="article__excerpt">We are co-organizers of the Swiss Cloud Native Day.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://www.meetup.com/cloudnativebern/"><img src="community/meetup.svg"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://www.meetup.com/cloudnativebern/">
-            Cloud Native Bern Meetup
-          </a></h2>
-          <p class="article__excerpt">We are co-organizers of the Cloud Native Bern Meetup.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://bernerit.rocks/"><img src="community/berneritrocks.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://bernerit.rocks/">
-            bernerit.rocks
-          </a></h2>
-          <p class="article__excerpt">We are co-founders of the association bernerit.rocks.</p>
-        </div>
-      </div>
-    </div>
-    <div class="article__hover col col-3 col-d-3 col-t-4">
-      <div class="article__inner">
-        <div class="article__head">
-          <div class="sqr_border"><div class="sqr">
-            <a href="https://digitalimpact.ch/"><img src="community/digitalimpact.png"></a>
-          </div></div>
-        </div>
-        <div class="article__content">
-          <h2 class="article__title"><a class="scl" href="https://digitalimpact.ch/">
-            Digital Impact Network
-          </a></h2>
-          <p class="article__excerpt">We are involved in the Digital Impact Network in the Cloud Native & DevOps specialist group.</p>
-        </div>
-      </div>
-    </div>
+  {{< grid-item
+      image="community/cloudnativeday.png"
+      title="Swiss Cloud Native Day"
+      text="We are co-organizers of the Swiss Cloud Native Day."
+      href="https://cloudnativeday.ch/" >}}
+  {{< grid-item
+      image="community/meetup.svg"
+      title="Cloud Native Bern Meetup"
+      text="We are co-organizers of the Cloud Native Bern Meetup."
+      href="https://www.meetup.com/cloudnativebern/" >}}
+  {{< grid-item
+      image="community/berneritrocks.png"
+      title="bernerit.rocks"
+      text="We are co-founders of the association bernerit.rocks."
+      href="https://bernerit.rocks/" >}}
+  {{< grid-item
+      image="community/digitalimpact.png"
+      title="Digital Impact Network"
+      text="We are involved in the Digital Impact Network in the Cloud Native & DevOps specialist group."
+      href="https://digitalimpact.ch/" >}}
 </div>

--- a/layouts/shortcodes/grid-item.html
+++ b/layouts/shortcodes/grid-item.html
@@ -1,0 +1,43 @@
+<div class="article{{ if .Get "href" }}__hover{{ end }} col col-3 col-d-3 col-t-4">
+    <div class="article__inner">
+        <div class="article__head">
+            <div class="sqr_border">
+                <div class="sqr">
+                    {{ with .Get "href" }}
+                        <a target="_blank" href="{{ . }}">
+                    {{ end }}
+                    {{ $image := .Page.Resources.Get (.Get "image") }}
+                    {{ $name := path.BaseName $image.Name }}
+                    {{ if eq $image.MediaType.SubType "svg" }}
+                        {{ $image = $image | fingerprint }}
+                        <img class="border" alt="{{ $name }}" src="{{ $image.Permalink }}">
+                    {{ else }}
+                        {{ $image := $image.Resize "200x" }}
+                        <img class="border" alt="{{ $name }}" src="{{ $image.Permalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}">
+                    {{ end }}
+                    {{ if .Get "href" }}
+                        </a>
+                    {{ end }}
+                </div>
+            </div>
+        </div>
+        {{ if or (.Get "title") (.Get "text") }}
+        <div class="article__content">
+            {{ if .Get "title" }}
+              <h2 class="article__title">
+                {{ with .Get "href" }}
+                  <a class="scl" target="_blank" href="{{ . }}">
+                {{ end }}
+                {{ .Get "title" }}
+                {{ if .Get "href" }}
+                  </a>
+                {{ end }}
+              </h2>
+            {{ end }}
+            {{ with .Get "text" }}
+            <p class="article__excerpt">{{ . }}</p>
+            {{ end }}
+        </div>
+        {{ end }}
+    </div>
+</div>


### PR DESCRIPTION
- Move more html into shortcodes
- Resize png images
- Add `alt` to image tags
- Open links in a new tab
- Fingerprint images, so we can enable long caching

I noticed that a few `div` elements were missing on the "about" page. The images are now a tad smaller.